### PR TITLE
Use native biometrics to unlock whenever it is available.

### DIFF
--- a/applock/build.gradle
+++ b/applock/build.gradle
@@ -14,12 +14,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 34
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 34
     }
     lintOptions {
             abortOnError false
@@ -40,5 +40,5 @@ repositories {
 
 dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation 'androidx.biometric:biometric:1.1.0-rc01'
+    implementation 'androidx.biometric:biometric:1.1.0'
 }

--- a/applock/src/main/java/com/bitcoin/applock/views/UnlockViewController.java
+++ b/applock/src/main/java/com/bitcoin/applock/views/UnlockViewController.java
@@ -50,10 +50,16 @@ public class UnlockViewController extends AppLockViewController implements AppLo
         FingerprintLockService fingerprintService = AppLock.getInstance(parent.getContext())
                 .getLockService(FingerprintLockService.class);
 
-        if (fingerprintService.isEnrolled(parent.getContext()))
+        if (biometricsLockService.isEnrollmentEligible(parent.getContext())){
+            setupBiometricUnlock();
+            return;
+        }
+
+        if (fingerprintService.isEnrolled(parent.getContext())) {
             setupFingerprintUnlock();
-        else
+        } else {
             setupPINUnlock();
+        }
     }
 
     protected void setupPINUnlock() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.6'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':applock', ':applock-sample'
+include ':applock'


### PR DESCRIPTION
Issue where user may accidentally enable fingerprint when their device did not support or used an unsupported thirdparty biometric hardware

https://bitcoincom.slack.com/archives/CDGJ3BJHM/p1692688744720799

- this change allows user to override the setting lock setting by letting their device become eligible for using native biometric authentication. 